### PR TITLE
fix(types): make ElementAttributes.url optional

### DIFF
--- a/src/pymax/types/domain/element.py
+++ b/src/pymax/types/domain/element.py
@@ -4,7 +4,7 @@ from .base import CamelModel
 
 
 class ElementAttributes(CamelModel):
-    url: str
+    url: str | None = None
 
 
 class Element(CamelModel):


### PR DESCRIPTION
## Проблема

У элементов-анимоджи и стикеров в ответе сервера поля `url` нет. Из-за строгой модели `ElementAttributes.url: str` это даёт `ValidationError` и ломает синхронизацию при логине, когда в истории/сообщениях встречаются такие элементы.

Сервер реально отдаёт `ElementAttributes` без `url`, то есть модель сейчас строже самого протокола.

## Изменение

```diff
 class ElementAttributes(CamelModel):
-    url: str
+    url: str | None = None
```

Делает `url` опциональным — по аналогии с уже опциональными полями в `Element` (`from_`, `attributes`). Обратной несовместимости нет: у элементов с `url` всё работает как прежде.

## Контекст

Гоняем PyMax в проде как HTTP-шлюз к MAX. В 2.1.2 вы уже приняли два фикса, которые мы держали локальными патчами (`LoginResponse.token` → Optional и guard `if response.token is not None` в `app.py`) — спасибо! Это последний оставшийся патч, после мержа сможем выпилить локальное патчирование полностью.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The element URL field is now optional instead of required, allowing elements to be created without providing a URL value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->