### PR TITLE
Fix photo URL validation with query parameters

### DIFF
--- a/src/pymax/files/photo.py
+++ b/src/pymax/files/photo.py
@@ -1,6 +1,7 @@
 import mimetypes
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from .base import BaseFile
 from .static import ALLOWED_EXTENSIONS
@@ -66,12 +67,13 @@ class Photo(BaseFile):
                 raise ValueError(msg)
             return (extension[1:], ("image/" + extension[1:]).lower())
         if self.url:
-            extension = Path(self.url).suffix.lower()
+            url_path = urlsplit(self.url).path
+            extension = Path(url_path).suffix.lower()
             if extension not in ALLOWED_EXTENSIONS:
                 msg = f"Invalid photo extension: {extension}. Allowed: {ALLOWED_EXTENSIONS}"
                 raise ValueError(msg)
 
-            mime_type = mimetypes.guess_type(self.url)[0]
+            mime_type = mimetypes.guess_type(url_path)[0]
 
             if not mime_type or not mime_type.startswith("image/"):
                 msg = f"URL does not appear to be an image: {self.url}"

--- a/tests/files/test_files_and_formatting.py
+++ b/tests/files/test_files_and_formatting.py
@@ -45,6 +45,12 @@ def test_file_and_photo_validation_errors() -> None:
         Photo(raw=b"not image", name="bad.txt").validate_photo()
 
 
+def test_photo_url_validation_ignores_query_string() -> None:
+    photo = Photo(url="https://example.com/image.jpg?quality=95&as=32x20")
+
+    assert photo.validate_photo() == ("jpg", "image/jpeg")
+
+
 def test_markdown_formatter_extracts_functional_entities() -> None:
     clean, entities = Formatter.format_markdown(
         "# Title\n> Quote\nHello **bold** and [site](https://example.com)"


### PR DESCRIPTION
## Описание
Исправляет проверку расширения для `Photo(url=...)`, когда URL содержит query-параметры. Теперь расширение и MIME-тип определяются по path-части URL, поэтому `image.jpg?quality=95` валидируется как `.jpg`.

## Тип изменений
- [x] Исправление бага
- [ ] Новая функциональность
- [ ] Улучшение документации
- [ ] Рефакторинг

## Связанные задачи / Issue
Fixes #58

## Тестирование
```bash
.venv/bin/python -m pytest -q tests/files/test_files_and_formatting.py
.venv/bin/ruff check src tests
.venv/bin/python -m pytest -q
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed photo URL validation to correctly handle URLs containing query parameters. The system now properly extracts file extension and MIME type information from photo URLs, regardless of any query strings appended to them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->