### PR TITLE
fix: keep frame decoding alive on non-dict payload

### DIFF
--- a/src/pymax/protocol/models.py
+++ b/src/pymax/protocol/models.py
@@ -16,7 +16,9 @@ class InboundFrame(BaseModel):
     cmd: int = 0
     seq: int | None = None
     payload: dict[Any, Any] | None = None
-    raw: dict[Any, Any] | None = None
+    # Не каждый фрейм несёт map: ответ-ошибка может прийти голым значением
+    # (например, числовым кодом), поэтому raw хранит исходный payload как есть.
+    raw: Any = None
 
 
 class TcpPacketHeader(BaseModel):

--- a/src/pymax/protocol/tcp/protocol.py
+++ b/src/pymax/protocol/tcp/protocol.py
@@ -59,14 +59,28 @@ class TcpProtocol(BaseProtocol):
             packed_packet.header.flags,
             packed_packet.header.payload_len,
         )
-        payload = self.payload_decoder.decode(
+        decoded = self.payload_decoder.decode(
             packed_packet.payload_bytes, flags=packed_packet.header.flags
         )
+
+        # Не каждый фрейм несёт map: например, ответ-ошибка приходит голым
+        # значением (числовым кодом). payload оставляем строго dict|None — его
+        # так читают консьюмеры, — а исходное значение кладём в raw, чтобы не
+        # терять данные и не ронять весь приём кадров на ValidationError.
+        payload = decoded if isinstance(decoded, dict) else None
+        if payload is None and decoded is not None:
+            logger.debug(
+                "non-dict tcp payload opcode=%s cmd=%s type=%s value=%r",
+                packed_packet.header.opcode,
+                packed_packet.header.cmd,
+                type(decoded).__name__,
+                decoded,
+            )
 
         return InboundFrame(
             opcode=packed_packet.header.opcode,
             cmd=packed_packet.header.cmd,
             seq=packed_packet.header.seq,
             payload=payload,
-            raw=payload,
+            raw=decoded,
         )

--- a/tests/protocol/test_protocols.py
+++ b/tests/protocol/test_protocols.py
@@ -52,6 +52,29 @@ def test_tcp_protocol_roundtrip() -> None:
     )
 
 
+def test_tcp_protocol_keeps_non_dict_payload_in_raw() -> None:
+    protocol = TcpProtocol()
+    framer = TcpPacketFramer()
+    # Сервер может прислать ответ-ошибку голым значением (не map). Раньше это
+    # роняло создание InboundFrame с ValidationError и убивало цикл приёма.
+    raw = framer.pack(
+        ver=protocol.version,
+        cmd=Command.ERROR,
+        seq=5,
+        opcode=Opcode.LOGIN,
+        flags=0,
+        payload_bytes=msgpack.packb(-12, use_bin_type=True),
+    )
+
+    decoded = protocol.decode(raw)
+
+    assert decoded.opcode == Opcode.LOGIN
+    assert decoded.cmd == Command.ERROR
+    assert decoded.seq == 5
+    assert decoded.payload is None
+    assert decoded.raw == -12
+
+
 def test_tcp_protocol_supports_two_byte_sequence_ids() -> None:
     protocol = TcpProtocol()
     outbound = OutboundFrame(


### PR DESCRIPTION
## Описание
Некоторые входящие фреймы несут payload не в виде map, а голым значением —
например, ответ-ошибка приходит числовым кодом. Поле `InboundFrame.payload`
типизировано как `dict | None`, поэтому создание фрейма падало с
`ValidationError` прямо в цикле приёма (`_recv_loop`). Это исключение
обрабатывается как фатальная ошибка соединения → разрыв и реконнект, а тот же
фрейм приходит снова → цикл реконнектов.

Изменения:
- `payload` остаётся `dict | None` (консьюмеры читают его именно так и уже
  гуардят `None`);
- исходное декодированное значение кладётся в `raw` (теперь `Any`), чтобы не
  терять данные (тот самый код ошибки) и не ронять приём кадров.

Обратной несовместимости нет: для обычных dict-фреймов `payload` и `raw`
ведут себя как раньше; поле `InboundFrame.raw` в коде нигде не читается.

## Тип изменений
- [x] Исправление бага
- [ ] Новая функциональность
- [ ] Улучшение документации
- [ ] Рефакторинг

## Связанные задачи / Issue
Ссылка на issue, если есть: #

## Тестирование
Добавлен регрессионный тест `test_tcp_protocol_keeps_non_dict_payload_in_raw`
в `tests/protocol/test_protocols.py`:

```python
import msgpack
from pymax.protocol import Command, Opcode
from pymax.protocol.tcp.framing import TcpPacketFramer
from pymax.protocol.tcp.protocol import TcpProtocol

p = TcpProtocol()
raw = TcpPacketFramer().pack(
    ver=p.version, cmd=Command.ERROR, seq=5, opcode=Opcode.LOGIN,
    flags=0, payload_bytes=msgpack.packb(-12, use_bin_type=True),
)
frame = p.decode(raw)        # раньше: ValidationError
assert frame.payload is None
assert frame.raw == -12
```

Запуск:
```
pytest tests/protocol/test_protocols.py
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced protocol message handling to properly preserve and process non-dictionary responses, including numeric codes, error values, and other non-structured data. These values are now correctly distinguished from structured payloads and properly stored, preventing potential data loss and processing errors when receiving such responses from the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->