### PR TITLE
fix(events): make ReactionUpdateEvent counters/total_count optional

### DIFF
--- a/src/pymax/types/events/reaction.py
+++ b/src/pymax/types/events/reaction.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from pymax.types.domain.base import CamelModel
 from pymax.types.domain.message import ReactionCounter
 
@@ -9,13 +11,14 @@ class ReactionUpdateEvent(CamelModel):
     :vartype message_id: str
     :ivar chat_id: ID чата.
     :vartype chat_id: int
-    :ivar counters: Счетчики реакций по типам.
+    :ivar counters: Счетчики реакций по типам. Пусто, когда реакцию сняли —
+        сервер шлёт ``NOTIF_MSG_REACTIONS_CHANGED`` (OP155) без ``counters``.
     :vartype counters: list[ReactionCounter]
-    :ivar total_count: Общее количество реакций.
+    :ivar total_count: Общее количество реакций (0 при снятии последней).
     :vartype total_count: int
     """
 
     message_id: str
     chat_id: int
-    counters: list[ReactionCounter]
-    total_count: int
+    counters: list[ReactionCounter] = Field(default_factory=list)
+    total_count: int = 0


### PR DESCRIPTION
## Problem

`ReactionUpdateEvent` declares `counters` and `total_count` as required. But when a reaction is **removed**, the server emits `NOTIF_MSG_REACTIONS_CHANGED` (opcode 155) **without** a `counters` field (and `total_count` 0):

```json
{"chatId": 531302608, "totalCount": 0, "messageId": "116781851510470562"}
```

This raises a `ValidationError` in `EventMapper.map` → `RuntimeError: Failed to dispatch inbound frame`, so reaction-removal events never reach `on_reaction_update`, and every removal spams the logs with a traceback:

```
ReactionUpdateEvent
counters
  Field required [type=missing, input_value={'chatId': ..., 'totalCount': 0, 'messageId': ...}]
```

Observed live on a linked-device session (real account, June 2026): add a reaction → OP155 with `counters`; remove it → OP155 without `counters` → crash.

## Fix

Default `counters` to an empty list and `total_count` to `0`, so removal frames validate cleanly — an empty `counters` simply signals "reaction removed".

## Notes

- Backward compatible: add/update frames (with `counters`) are unaffected.
- Verified against the real removal payload (validates, `counters == []`) and a normal add payload (parses counters as before).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reaction event handling by adding sensible default values for reaction counters and total count, ensuring the system gracefully handles reaction data without requiring all fields to be explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->