### PR TITLE
Запрос списка участников чата/группы.

### DIFF
--- a/src/pymax/api/chats/enums.py
+++ b/src/pymax/api/chats/enums.py
@@ -22,6 +22,7 @@ class ChatPayloadKey(str, Enum):
     CHAT = "chat"
     CHATS = "chats"
     MEMBERS = "members"
+    MARKER = "marker"
 
 
 class ChatLinkPrefix(str, Enum):

--- a/src/pymax/api/chats/payloads.py
+++ b/src/pymax/api/chats/payloads.py
@@ -95,6 +95,13 @@ class GetChatInfoPayload(CamelModel):
     chat_ids: list[int]
 
 
+class GetChatMembersPayload(CamelModel):
+    type: str = "MEMBER"  # TODO: ENUMM!!!
+    chat_id: int
+    marker: int
+    count: int = 50
+
+
 class LeaveChatPayload(CamelModel):
     chat_id: int
 

--- a/src/pymax/api/chats/service.py
+++ b/src/pymax/api/chats/service.py
@@ -272,8 +272,9 @@ class ChatService:
         self,
         chat_id: int,
         marker: int | None = None,
+        count: int = 50,
     ) -> tuple[list[Member], int]:
-        frame = GetChatMembersPayload(chat_id=chat_id, marker=marker or 0)
+        frame = GetChatMembersPayload(chat_id=chat_id, marker=marker or 0, count=count)
         response = await self.app.invoke(Opcode.CHAT_MEMBERS, frame.to_payload())
 
         members = bind_api_model(

--- a/src/pymax/api/chats/service.py
+++ b/src/pymax/api/chats/service.py
@@ -27,6 +27,7 @@ from .payloads import (
     FetchChatsPayload,
     FetchJoinRequests,
     GetChatInfoPayload,
+    GetChatMembersPayload,
     InviteUsersPayload,
     JoinChatPayload,
     JoinRequestActionPayload,
@@ -265,6 +266,14 @@ class ChatService:
                 cached[chat.id] = chat
 
         return [cached[chat_id] for chat_id in chat_ids if chat_id in cached]
+
+    async def get_chat_members(self, chat_id: int, marker: int | None = None) -> list[Member]:
+        frame = GetChatMembersPayload(chat_id=chat_id, marker=marker or 0)
+        response = await self.app.invoke(Opcode.CHAT_MEMBERS, frame.to_payload())
+        return bind_api_model(
+            self.app,
+            parse_payload_list(response, ChatPayloadKey.MEMBERS, Member),
+        )
 
     async def get_chat(self, chat_id: int) -> Chat:
         chats = await self.get_chats([chat_id])

--- a/src/pymax/api/chats/service.py
+++ b/src/pymax/api/chats/service.py
@@ -7,6 +7,7 @@ from pymax.api.binding import bind_api_model
 from pymax.api.response import (
     parse_payload_item_model,
     parse_payload_list,
+    payload_item,
     require_payload_item_model,
     require_payload_model,
 )
@@ -267,13 +268,20 @@ class ChatService:
 
         return [cached[chat_id] for chat_id in chat_ids if chat_id in cached]
 
-    async def get_chat_members(self, chat_id: int, marker: int | None = None) -> list[Member]:
+    async def get_chat_members(
+        self,
+        chat_id: int,
+        marker: int | None = None,
+    ) -> tuple[list[Member], int]:
         frame = GetChatMembersPayload(chat_id=chat_id, marker=marker or 0)
         response = await self.app.invoke(Opcode.CHAT_MEMBERS, frame.to_payload())
-        return bind_api_model(
+
+        members = bind_api_model(
             self.app,
             parse_payload_list(response, ChatPayloadKey.MEMBERS, Member),
         )
+        next_marker = payload_item(response, ChatPayloadKey.MARKER, int) or 0
+        return members, next_marker
 
     async def get_chat(self, chat_id: int) -> Chat:
         chats = await self.get_chats([chat_id])

--- a/src/pymax/infra/chat.py
+++ b/src/pymax/infra/chat.py
@@ -215,12 +215,15 @@ class ChatMixin(IClientProtocol):
         self,
         chat_id: int,
         marker: int | None = None,
+        count: int = 50,
     ) -> tuple[list[Member], int]:
         """Возвращает страницу участников чата по ID.
 
         Args:
             chat_id: ID чата.
-            marker: Маркер страницы.
+            marker: Маркер страницы. Если ``None``, запрашивается первая
+                страница.
+            count: Максимальное количество участников в ответе.
 
         Returns:
             ``(members, next_marker)``. Если участников больше, чем
@@ -228,7 +231,7 @@ class ChatMixin(IClientProtocol):
             следующий вызов, чтобы получить следующую страницу. ``0``
             означает, что дальше страниц нет.
         """
-        return await self._app.api.chats.get_chat_members(chat_id, marker)
+        return await self._app.api.chats.get_chat_members(chat_id, marker, count)
 
     async def leave_group(self, chat_id: int) -> None:
         """Выходит из группы.

--- a/src/pymax/infra/chat.py
+++ b/src/pymax/infra/chat.py
@@ -211,19 +211,22 @@ class ChatMixin(IClientProtocol):
         """
         return await self._app.api.chats.get_chat(chat_id)
 
-    async def get_chat_members(self, chat_id: int, marker: int | None = None) -> list[Member]:
-        """Возвращает участников чата по ID.
+    async def get_chat_members(
+        self,
+        chat_id: int,
+        marker: int | None = None,
+    ) -> tuple[list[Member], int]:
+        """Возвращает страницу участников чата по ID.
 
         Args:
             chat_id: ID чата.
-            marker: Маркер пагинации. Если ``None``, запрашивается первая
-                страница.
+            marker: Маркер страницы.
 
         Returns:
-            Список участников.
-
-        Raises:
-            PyMaxError: Если сервер не вернул участников.
+            ``(members, next_marker)``. Если участников больше, чем
+            уместилось в ответ, ``next_marker`` ненулевой — передайте его в
+            следующий вызов, чтобы получить следующую страницу. ``0``
+            означает, что дальше страниц нет.
         """
         return await self._app.api.chats.get_chat_members(chat_id, marker)
 

--- a/src/pymax/infra/chat.py
+++ b/src/pymax/infra/chat.py
@@ -211,6 +211,22 @@ class ChatMixin(IClientProtocol):
         """
         return await self._app.api.chats.get_chat(chat_id)
 
+    async def get_chat_members(self, chat_id: int, marker: int | None = None) -> list[Member]:
+        """Возвращает участников чата по ID.
+
+        Args:
+            chat_id: ID чата.
+            marker: Маркер пагинации. Если ``None``, запрашивается первая
+                страница.
+
+        Returns:
+            Список участников.
+
+        Raises:
+            PyMaxError: Если сервер не вернул участников.
+        """
+        return await self._app.api.chats.get_chat_members(chat_id, marker)
+
     async def leave_group(self, chat_id: int) -> None:
         """Выходит из группы.
 


### PR DESCRIPTION
## Описание
Добавляет возможность получения списка участников чата или группы. 

При работе с библиотекой оказалось, что chat = await client.get_chat(channel_id) и последующий chat.participants выдают только 1 участника. Проверил в протоколе - действительно, данные не передаются. Написал метод по получению всех участников.

## Тип изменений
- [ ] Исправление бага
- [x] Новая функциональность
- [ ] Улучшение документации
- [ ] Рефакторинг

## Связанные задачи / Issue
Ссылка на issue, если есть: #

## Тестирование
Покажите пример кода, который проверяет изменения:

```python
import pymax

# пример использования нового функционала
chat = await client.get_chat(channel_id)
members, marker = await client.get_chat_members(channel_id)
all_members = list(members)
while marker:
    page, marker = await client.get_chat_members(channel_id, marker)
    all_members.extend(page)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve chat members.
  * Supports optional pagination to load additional participants, returning both the current member page and a next-page marker when more results are available.
  * Returned participants are provided as fully integrated member objects for use across the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->