### PR TITLE
Update websocket.py

### DIFF
--- a/src/pymax/transport/websocket.py
+++ b/src/pymax/transport/websocket.py
@@ -4,6 +4,10 @@ from websockets.asyncio import client
 from pymax.logging import get_logger
 
 from .base import Transport
+import ssl
+ssl_context = ssl.create_default_context()
+ssl_context.check_hostname = False
+ssl_context.verify_mode = ssl.CERT_NONE
 
 logger = get_logger(__name__)
 
@@ -17,11 +21,11 @@ class WebSocketTransport(Transport):
     async def connect(self) -> None:
         if self.proxy:
             self.ws = await client.connect(
-                self.url, origin=Origin("https://web.max.ru"), proxy=self.proxy
+                self.url, origin=Origin("https://web.max.ru"), proxy=self.proxy, ssl=ssl_context,
             )
         else:
             self.ws = await client.connect(
-                self.url, origin=Origin("https://web.max.ru")
+                self.url, origin=Origin("https://web.max.ru"), ssl=ssl_context,
             )  # TODO: origin should be configurable
 
     async def close(self) -> None:


### PR DESCRIPTION
Fix SSL error:
Traceback (most recent call last):
 File "pymax/base.py", line 131, in start
 File "pymax/app.py", line 88, in start
ConnectionError: Failed to connect and handshake: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:992)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebSocket connection SSL configuration to improve compatibility across different certificate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->