### PR TITLE
fix(events): accept numeric reaction message ids

### DIFF
--- a/src/pymax/types/events/reaction.py
+++ b/src/pymax/types/events/reaction.py
@@ -6,7 +6,7 @@ class ReactionUpdateEvent(CamelModel):
     """Событие обновления реакций сообщения.
 
     :ivar message_id: ID сообщения.
-    :vartype message_id: str
+    :vartype message_id: int
     :ivar chat_id: ID чата.
     :vartype chat_id: int
     :ivar counters: Счетчики реакций по типам.
@@ -15,7 +15,7 @@ class ReactionUpdateEvent(CamelModel):
     :vartype total_count: int
     """
 
-    message_id: str
+    message_id: int
     chat_id: int
     counters: list[ReactionCounter] | None = None
     total_count: int = 0

--- a/tests/dispatch/test_dispatcher.py
+++ b/tests/dispatch/test_dispatcher.py
@@ -217,7 +217,7 @@ async def test_dispatcher_maps_reaction_update_event() -> None:
     router: Router[str] = Router()
     dispatcher: Dispatcher[str] = Dispatcher(app, router)
     dispatcher.bind_client("client")
-    seen: list[tuple[str, int, int, int, str]] = []
+    seen: list[tuple[int, int, int, int, str]] = []
 
     @router.on_reaction_update()
     async def on_reaction_update(event, _client):
@@ -234,7 +234,7 @@ async def test_dispatcher_maps_reaction_update_event() -> None:
     await dispatcher.dispatch(
         frame(
             {
-                "messageId": "116739131144745294",
+                "messageId": 116739131144745294,
                 "chatId": 239067070,
                 "counters": [{"count": 1, "reaction": "👍"}],
                 "totalCount": 1,
@@ -244,7 +244,7 @@ async def test_dispatcher_maps_reaction_update_event() -> None:
         )
     )
 
-    assert seen == [("116739131144745294", 239067070, 1, 1, "👍")]
+    assert seen == [(116739131144745294, 239067070, 1, 1, "👍")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Описание

MAX может прислать `messageId` события `NOTIF_MSG_REACTIONS_CHANGED` числом. `ReactionUpdateEvent` принимал только строку, поэтому Pydantic отклонял payload и dispatcher терял событие.

Модель теперь строго принимает `int` в соответствии с текущим wire-format MAX. Регрессионный тест проводит числовой ID через настоящий dispatcher и проверяет доставленное обработчику событие.

Изменение ограничено разбором payload. Поведение доставки событий со стороны сервера, описанное в #97, не меняется.

## Тип изменений

- [x] Исправление бага
- [ ] Новая функциональность
- [ ] Улучшение документации
- [ ] Рефакторинг

## Связанные задачи / Issue

Fixes #96

## Тестирование

- `uv run pytest tests/dispatch/test_dispatcher.py::test_dispatcher_maps_reaction_update_event` — passed
- `uv run ruff format --check src/pymax/types/events/reaction.py tests/dispatch/test_dispatcher.py`
- `uv run ruff check src/pymax/types/events/reaction.py tests/dispatch/test_dispatcher.py`
- `uv run pre-commit run --files src/pymax/types/events/reaction.py tests/dispatch/test_dispatcher.py`
