### PR TITLE
fix: preserve intraword markdown markers

### DIFF
--- a/src/pymax/formatting/markdown.py
+++ b/src/pymax/formatting/markdown.py
@@ -53,7 +53,7 @@ class Formatter:
 
     @staticmethod
     def _is_intraword_single_marker(text: str, i: int, marker: str) -> bool:
-        if marker not in {"_", "*"}:
+        if marker != "_":
             return False
         if i == 0 or i + 1 >= len(text):
             return False

--- a/src/pymax/formatting/markdown.py
+++ b/src/pymax/formatting/markdown.py
@@ -52,6 +52,29 @@ class Formatter:
         return label, url, url_end + 1
 
     @staticmethod
+    def _is_intraword_single_marker(text: str, i: int, marker: str) -> bool:
+        if marker not in {"_", "*"}:
+            return False
+        if i == 0 or i + 1 >= len(text):
+            return False
+        return text[i - 1].isalnum() and text[i + 1].isalnum()
+
+    @staticmethod
+    def _find_closing_marker(
+        text: str,
+        marker: str,
+        start: int,
+        end: int | None = None,
+    ) -> int:
+        while True:
+            closing_index = text.find(marker, start, len(text) if end is None else end)
+            if closing_index == -1:
+                return -1
+            if not Formatter._is_intraword_single_marker(text, closing_index, marker):
+                return closing_index
+            start = closing_index + len(marker)
+
+    @staticmethod
     def format_markdown(text: str) -> tuple[str, list[Element]]:
         clean_text = ""
         entities: list[Element] = []
@@ -155,6 +178,8 @@ class Formatter:
             for marker in Formatter.MARKER_ORDER:
                 if not text.startswith(marker, i):
                     continue
+                if Formatter._is_intraword_single_marker(text, i, marker):
+                    continue
 
                 marker_len = len(marker)
 
@@ -180,7 +205,8 @@ class Formatter:
                         break
 
                     end = text.find("\n", i + marker_len)
-                    closing_index = text.find(
+                    closing_index = Formatter._find_closing_marker(
+                        text,
                         marker,
                         i + marker_len,
                         None if end == -1 else end,

--- a/tests/files/test_files_and_formatting.py
+++ b/tests/files/test_files_and_formatting.py
@@ -70,3 +70,29 @@ def test_markdown_formatter_extracts_functional_entities() -> None:
     ]
     assert entities[-1].attributes is not None
     assert entities[-1].attributes.url == "https://example.com"
+
+
+def test_markdown_formatter_preserves_intraword_single_markers() -> None:
+    text = "https://max.ru/channel_iclub_new snake_case_name цена 5*2 = 10"
+
+    clean, entities = Formatter.format_markdown(text)
+
+    assert clean == text
+    assert entities == []
+
+
+def test_markdown_formatter_preserves_unclosed_single_marker_before_intraword_marker() -> None:
+    clean, entities = Formatter.format_markdown("_foo_bar")
+
+    assert clean == "_foo_bar"
+    assert entities == []
+
+
+def test_markdown_formatter_still_parses_delimited_single_marker_emphasis() -> None:
+    clean, entities = Formatter.format_markdown("Hello _world_ and *again*")
+
+    assert clean == "Hello world and again"
+    assert [(entity.type, entity.from_, entity.length) for entity in entities] == [
+        ("EMPHASIZED", 6, 5),
+        ("EMPHASIZED", 16, 5),
+    ]

--- a/tests/files/test_files_and_formatting.py
+++ b/tests/files/test_files_and_formatting.py
@@ -96,3 +96,12 @@ def test_markdown_formatter_still_parses_delimited_single_marker_emphasis() -> N
         ("EMPHASIZED", 6, 5),
         ("EMPHASIZED", 16, 5),
     ]
+
+
+def test_markdown_formatter_still_parses_intraword_asterisk_emphasis() -> None:
+    clean, entities = Formatter.format_markdown("foo*bar*baz")
+
+    assert clean == "foobarbaz"
+    assert [(entity.type, entity.from_, entity.length) for entity in entities] == [
+        ("EMPHASIZED", 3, 3),
+    ]


### PR DESCRIPTION
## Описание
Исправляет обработку одиночных markdown-маркеров `_` и `*` внутри слов/URL: такие символы теперь сохраняются как обычный текст, поэтому ссылки вроде `channel_iclub_new` и `snake_case_name` не ломаются. Разделённое подчёркиванием/звёздочками выделение (`_world_`, `*again*`) продолжает парситься.

## Тип изменений
- [x] Исправление бага
- [ ] Новая функциональность
- [ ] Улучшение документации
- [ ] Рефакторинг

## Связанные задачи / Issue
Fixes #100

## Тестирование
RED до исправления: новый `test_markdown_formatter_preserves_intraword_single_markers` падал, потому что `channel_iclub_new` превращался в `channeliclubnew`.

Проверено:

```bash
uv run pytest tests/files/test_files_and_formatting.py -q -k 'markdown_formatter'
uv run pytest tests/files/test_files_and_formatting.py -q
uv run pytest -q
uv run ruff check src/pymax/formatting/markdown.py tests/files/test_files_and_formatting.py
uv run ruff format --check src/pymax/formatting/markdown.py tests/files/test_files_and_formatting.py
python -m compileall -q src/pymax/formatting/markdown.py tests/files/test_files_and_formatting.py
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Улучшена обработка Markdown-маркеров `_` и `*` внутри слов.
  * Незакрытые маркеры, например в `_foo_bar`, сохраняются как обычный текст.
  * Выделение отдельных слов с помощью `_слово_` и `*слово*` продолжает работать корректно.
  * Парные звёздочки внутри слова распознаются как выделение.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->